### PR TITLE
feat: jaehyun_ewg_db 노트북 모듈화 통합 (#15)

### DIFF
--- a/02_src/01_data/00_ingestion/loader.py
+++ b/02_src/01_data/00_ingestion/loader.py
@@ -79,3 +79,13 @@ def load_all_raw(config: dict = None):
         val_cfg["hwahae"]["required_cols"]
     )
     return df_pc, df_coos, df_hwahae
+
+
+def load_ewg(raw_dir: str, filename: str, required_cols: list) -> pd.DataFrame:
+    """coos_성분정보.csv (EWG 스코어 원본) 로드"""
+    path = os.path.join(raw_dir, filename)
+    _check_file(path)
+    df = pd.read_csv(path, encoding="utf-8-sig")
+    _validate_schema(df, required_cols, "EWG")
+    logger.info(f"[EWG] 로드 완료: {df.shape}")
+    return df

--- a/02_src/01_data/01_preprocessing/cleaner.py
+++ b/02_src/01_data/01_preprocessing/cleaner.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import re
 
 _HERE   = os.path.dirname(os.path.abspath(__file__))
 _COMMON = os.path.join(_HERE, "..", "..", "00_common")
@@ -76,4 +77,38 @@ def apply_score_mapping(df: pd.DataFrame, pre_cfg: dict) -> pd.DataFrame:
             lambda v: _map_pc_rating(v, pre_cfg["pc_rating_map"])
         )
     logger.info("[스코어 변환] 완료")
+    return df
+
+
+def parse_ewg_score(raw) -> int:
+    """EWG 스코어 파싱 (범위 → 끝값, 없으면 0)"""
+    if raw is None:
+        return 0
+    raw_str = str(raw).strip()
+    if raw_str in ("", "nan", "None", "N/A", "-"):
+        return 0
+    cleaned = re.sub(r"[^\d\-–]", " ", raw_str).strip()
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    range_match = re.match(r"^(\d+)\s*[-–]\s*(\d+)$", cleaned)
+    if range_match:
+        return int(range_match.group(2))
+    single_match = re.match(r"^(\d+)$", cleaned)
+    if single_match:
+        return int(single_match.group(1))
+    numbers = re.findall(r"\d+", cleaned)
+    if numbers:
+        return int(numbers[-1])
+    return 0
+
+
+def clean_ewg(df: pd.DataFrame, ing_col: str, score_col: str) -> pd.DataFrame:
+    """EWG 원본 → score_parsed + ingredient_key 컬럼 생성, 빈 성분명 제거"""
+    df = df.copy()
+    df["score_parsed"] = df[score_col].apply(parse_ewg_score)
+    df = df[
+        df[ing_col].notna() &
+        (df[ing_col].astype(str).str.strip() != "")
+    ].copy()
+    df["ingredient_key"] = df[ing_col].astype(str).str.strip().str.lower()
+    logger.info(f"[EWG cleaner] 완료: {df.shape}")
     return df

--- a/02_src/01_data/01_preprocessing/merger.py
+++ b/02_src/01_data/01_preprocessing/merger.py
@@ -57,3 +57,19 @@ def build_product_db(df_hwahae_raw: pd.DataFrame,
     df = df.rename(columns=product_cfg["rename_cols"])
     logger.info(f"[product_db] 생성 완료: {df.shape}")
     return df
+
+
+def merge_ewg_scores(df: pd.DataFrame, ing_col: str) -> pd.DataFrame:
+    """중복 성분명 병합 — 0 아닌 유효값 우선, 없으면 0"""
+    merged_rows = []
+    for key, group in df.groupby("ingredient_key"):
+        valid_scores = [s for s in group["score_parsed"].tolist() if s != 0]
+        score = valid_scores[0] if valid_scores else 0
+        representative = group[ing_col].astype(str).str.strip().value_counts().idxmax()
+        merged_rows.append({
+            "ingredient": representative,
+            "coos_score": int(score),
+        })
+    result = pd.DataFrame(merged_rows).sort_values("ingredient").reset_index(drop=True)
+    logger.info(f"[EWG merge] 병합 후: {result.shape}")
+    return result

--- a/03_scripts/05_build_ewg_db.py
+++ b/03_scripts/05_build_ewg_db.py
@@ -1,0 +1,38 @@
+"""
+03_scripts/05_build_ewg_db.py
+EWG 성분 DB 빌드 스크립트
+실행: python 03_scripts/05_build_ewg_db.py
+"""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "02_src", "00_common"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "02_src", "01_data", "00_ingestion"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "02_src", "01_data", "01_preprocessing"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "02_src", "01_data", "02_io"))
+
+from config_loader import load_config, resolve_path, resolve_output
+from loader  import load_ewg
+from cleaner import clean_ewg
+from merger  import merge_ewg_scores
+from writer  import save_csv, save_df_as_json
+
+def main():
+    cfg      = load_config()
+    raw_dir  = resolve_path(cfg, "raw_dir")
+    ewg_cfg  = cfg["preprocessing"]["ewg"]
+    val_cfg  = cfg["validation"]["ewg"]
+
+    # 1. 로드
+    df_raw = load_ewg(raw_dir, cfg["paths"]["raw_files"]["ewg"], val_cfg["required_cols"])
+
+    # 2. 정제
+    df_clean = clean_ewg(df_raw, ewg_cfg["ing_col"], ewg_cfg["score_col"])
+
+    # 3. 병합
+    df_merged = merge_ewg_scores(df_clean, ewg_cfg["ing_col"])
+
+    # 4. 저장
+    save_csv(df_merged, resolve_output(cfg, "ewg_csv"))
+
+
+if __name__ == "__main__":
+    main()

--- a/04_configs/config.yaml
+++ b/04_configs/config.yaml
@@ -12,11 +12,13 @@ paths:
     paulaschoice: "paulaschoice_ingredients.csv"
     coos:         "coos_성분정보.csv"
     hwahae:       "hwahae_all.csv"
+    ewg:          "coos_성분정보.csv"
 
   output_files:
-    merged_json:  "ingredient_merged2.json"
-    product_db:   "product_db.csv"
-    chunk_prefix: "ingredient_chunks_preset"
+    merged_json:  "ingredient_merged2.json" # 3소스 병합 성분 DB
+    product_db:   "product_db.csv" # 화해 상품 정보 DB
+    chunk_prefix: "ingredient_chunks_preset" # 임베딩용 청크 (preset1~4)
+    ewg_csv:      "coos_ewg_cleaned.csv" # EWG 스코어 DB - coos 원본명
 
 # ── 검증 설정 ────────────────────────────────────────────────
 validation:
@@ -26,6 +28,8 @@ validation:
     required_cols: ["성분명", "INCI", "기능", "스코어"]
   hwahae:
     required_cols: ["korean", "english", "product_id", "product_name"]
+  ewg:
+    required_cols: ["성분명", "스코어"]   # ← 여기에 추가
 
 # ── 전처리 설정 ──────────────────────────────────────────────
 preprocessing:
@@ -114,6 +118,10 @@ preprocessing:
     보통:      3
     나쁨:      4
     매우 나쁨: 5
+
+  ewg:
+    ing_col:   "성분명"
+    score_col: "스코어"
 
 # ── product_db 컬럼 설정 ─────────────────────────────────────
 product_db:


### PR DESCRIPTION
## 개요
jaehyun_ewg_db.ipynb 노트북 코드를 모듈 구조에 통합했습니다.

## 변경 파일
- `02_src/01_data/00_ingestion/loader.py` — load_ewg() 추가
- `02_src/01_data/01_preprocessing/cleaner.py` — parse_ewg_score(), clean_ewg() 추가
- `02_src/01_data/01_preprocessing/merger.py` — merge_ewg_scores() 추가
- `03_scripts/05_build_ewg_db.py` — 신규 생성
- `04_configs/config.yaml` — ewg 설정 추가

## 실행 방법
```
python 03_scripts/05_build_ewg_db.py
```

## 출력 결과
- `00_data/02_processed/coos_ewg_cleaned.csv` (18,178건)

## 관련이슈
#15